### PR TITLE
TokenSelector: Disable dropdown if no other tokens

### DIFF
--- a/src/components/TokenSelector.vue
+++ b/src/components/TokenSelector.vue
@@ -66,10 +66,11 @@ const dropdownItems = computed(() => {
 	}
 })
 
+const hasDropdownItems = computed(() => dropdownItems.value.length > 0)
 </script>
 
 <template>
-	<Dropdown>
+	<Dropdown v-if="hasDropdownItems">
 		<template #trigger="{isOpen}">
 			<Flex align="center" gap="6" :class="$style.selector">
 				<img width="20" height="20" :src="loadImage(selectedToken.icon)" alt="" />
@@ -103,6 +104,15 @@ const dropdownItems = computed(() => {
 			</DropdownItem>
 		</template>
 	</Dropdown>
+	<Flex v-else align="center" gap="6" :class="$style.selector">
+		<img width="20" height="20" :src="loadImage(selectedToken.icon)" alt="" />
+		<Text size="16" color="primary"> {{ selectedToken.ticker }} </Text>
+		<Icon
+			name="chevron-right"
+			size="14"
+			color="tertiary"
+		/>
+	</Flex>
 </template>
 
 <style module>


### PR DESCRIPTION
The application freezes when there is only one token, and the user clicks on the `TokenSelector`. This quick fix checks if there are any items to display in the `Dropdown` and uses conditional rendering. If the `Dropdown` has no items, clicking it will have no effect, preventing the freeze.